### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-torq/main.go
+++ b/cmd/baton-torq/main.go
@@ -47,7 +47,7 @@ func getConnector(ctx context.Context, cc *cfg.Torq) (types.ConnectorServer, err
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, cc.TorqClientId, cc.TorqClientSecret)
+	cb, err := connector.New(ctx, cc.TorqClientId, cc.TorqClientSecret, cc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Torq struct {
 	TorqClientId string `mapstructure:"torq-client-id"`
 	TorqClientSecret string `mapstructure:"torq-client-secret"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Torq) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Torq API URL (for testing)"),
+		field.WithHidden(true),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,11 @@ var (
 		field.WithDisplayName("Client Secret"),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Torq API URL (for testing)"),
+	)
+
 	// FieldRelationships defines relationships between the fields listed in
 	// Config that can be automatically validated.
 	FieldRelationships = []field.SchemaFieldRelationship{}
@@ -31,6 +36,7 @@ var (
 var Config = field.NewConfiguration([]field.SchemaField{
 	TorqClientId,
 	TorqClientSecret,
+	BaseURLField,
 })
 
 // ValidateConfig is run after the configuration is loaded, and should return an

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Torq API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -43,7 +43,7 @@ func (c *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, clientId string, clientSecret string) (*Connector, error) {
+func New(ctx context.Context, clientId string, clientSecret string, baseURL string) (*Connector, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
@@ -55,6 +55,6 @@ func New(ctx context.Context, clientId string, clientSecret string) (*Connector,
 	}
 
 	return &Connector{
-		client: torq.NewClient(httpClient, token),
+		client: torq.NewClient(httpClient, token, baseURL),
 	}, nil
 }

--- a/pkg/torq/client.go
+++ b/pkg/torq/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 )
 
-const BaseUrl = "https://api.torq.io/public/v1alpha/"
+const DefaultBaseURL = "https://api.torq.io/public/v1alpha/"
 
 type AuthResponse struct {
 	AccessToken string `json:"access_token"`
@@ -22,12 +22,17 @@ type AuthResponse struct {
 type Client struct {
 	httpClient *http.Client
 	token      string
+	baseURL    string
 }
 
-func NewClient(httpClient *http.Client, token string) *Client {
+func NewClient(httpClient *http.Client, token string, baseURL string) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
 	return &Client{
 		httpClient: httpClient,
 		token:      token,
+		baseURL:    baseURL,
 	}
 }
 
@@ -74,7 +79,7 @@ func (c *Client) listLocalUsers(ctx context.Context) ([]User, error) {
 		Users []User `json:"users"`
 	}
 
-	usersUrl, _ := url.JoinPath(BaseUrl, "users")
+	usersUrl, _ := url.JoinPath(c.baseURL, "users")
 	if err := c.doRequest(ctx, usersUrl, &res, nil); err != nil {
 		return nil, err
 	}
@@ -88,7 +93,7 @@ func (c *Client) listSsoUsers(ctx context.Context) ([]User, error) {
 		Users []User `json:"users"`
 	}
 
-	usersUrl, _ := url.JoinPath(BaseUrl, "users")
+	usersUrl, _ := url.JoinPath(c.baseURL, "users")
 	q := url.Values{}
 	q.Add("sso_provision", "true")
 	if err := c.doRequest(ctx, usersUrl, &res, q); err != nil {
@@ -127,8 +132,8 @@ func (c *Client) ListRoles(ctx context.Context, pageToken string) ([]Role, strin
 	q := url.Values{}
 	q.Add("page_token", pageToken)
 
-	url, _ := url.JoinPath(BaseUrl, "users/roles")
-	if err := c.doRequest(ctx, url, &res, q); err != nil {
+	rolesUrl, _ := url.JoinPath(c.baseURL, "users/roles")
+	if err := c.doRequest(ctx, rolesUrl, &res, q); err != nil {
 		return nil, "", err
 	}
 

--- a/pkg/torq/client.go
+++ b/pkg/torq/client.go
@@ -16,6 +16,7 @@ import (
 const DefaultBaseURL = "https://api.torq.io/public/v1alpha/"
 
 type AuthResponse struct {
+	//nolint:gosec,nolintlint // G117: legitimate field name, not a credential
 	AccessToken string `json:"access_token"`
 }
 
@@ -54,7 +55,7 @@ func RequestAccessToken(ctx context.Context, clientID, clientSecret string) (str
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Basic "+authHeader)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := httpClient.Do(req)
+	resp, err := httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return "", err
 	}
@@ -156,7 +157,7 @@ func (c *Client) doRequest(ctx context.Context, path string, res interface{}, pa
 
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", c.token))
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req) //nolint:gosec,nolintlint // G704: URL constructed from trusted config
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-torq/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go,pkg/torq/client.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-torq --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.