### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: Set up a Torq connector
 og:title: Set up a Torq connector - C1 docs
-og:description: Integrate your Torq instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
-description: C1 provides identity governance and just-in-time provisioning for Torq. Integrate your Torq instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
+og:description: "C1 provides identity governance for Torq. Integrate your Torq instance with C1 for unified visibility and governance over user access."
+description: "C1 provides identity governance for Torq. Integrate your Torq instance with C1 for unified visibility and governance over user access."
 sidebarTitle: Torq
 ---
 
@@ -41,7 +41,7 @@ Click **Create**.
 Carefully and copy and save the key's client ID and client secret. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Torq connector
 
@@ -97,7 +97,7 @@ Click **Save**.
 The connector's label changes to **Syncing**, followed by **Connected**. You can view the logs to ensure that information is syncing.
 </Step>
 </Steps>
-**That's it!** Your Torq connector is now pulling access data into C1.
+**Done.** Your Torq connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 
@@ -214,7 +214,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Torq connector is now pulling access data into C1.
+**Done.** Your Torq connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines